### PR TITLE
💄 Wordのリストをブロック化

### DIFF
--- a/.github/workflows/test_and_build_check_at_pr.yaml
+++ b/.github/workflows/test_and_build_check_at_pr.yaml
@@ -8,6 +8,11 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: ./language-app
+
     steps:
       - name: リポジトリをチェックアウト
         uses: actions/checkout@v4
@@ -25,12 +30,15 @@ jobs:
 
   reviewdog:
     runs-on: ubuntu-latest
+
     defaults:
       run:
         working-directory: ./language-app
+
     permissions:
       contents: read # リポジトリの内容を読み取り可能にする
       pull-requests: write # プルリクエストのコメントを追加できるようにする
+
     steps:
       - name: リポジトリをチェックアウト
         uses: actions/checkout@v4

--- a/.github/workflows/test_and_build_check_at_pr.yaml
+++ b/.github/workflows/test_and_build_check_at_pr.yaml
@@ -57,3 +57,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-review # GitHub PRレビューとしてコメントを追加
           eslint_flags: "src/"
+          workdir: ./language-app

--- a/.github/workflows/test_and_build_check_at_pr.yaml
+++ b/.github/workflows/test_and_build_check_at_pr.yaml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: ./front
+        working-directory: ./language-app
     permissions:
       contents: read # リポジトリの内容を読み取り可能にする
       pull-requests: write # プルリクエストのコメントを追加できるようにする

--- a/language-app/src/app/word-search/_components/WordCard.tsx
+++ b/language-app/src/app/word-search/_components/WordCard.tsx
@@ -5,26 +5,27 @@ import { motion } from "motion/react";
 import Link from "next/link";
 import React from "react";
 
-// WordCardコンポーネントを分離（後述）
 export const WordCard = React.memo(({ word }: { word: Word }) => (
-  <Card className="text-background max-w-full">
-    <CardContent>
+  <Card className="text-background max-w-full sm:aspect-square">
+    <CardContent className="p-4 h-full">
       <motion.div
         whileHover={{ scale: 1.05 }}
         whileTap={{ scale: 1.1 }}
         transition={{ type: "spring", stiffness: 400, damping: 10 }}
+        className="h-full"
       >
         <Link
           href={`/word-search/${word.id}`}
-          className="block hover:bg-gray-50"
+          className="block hover:bg-gray-50 h-full sm:flex sm:flex-col sm:items-center sm:justify-center sm:text-center"
         >
-          <div className="grid grid-cols-10 auto-rows-auto">
-            <span className="col-span-7 font-bold break-words">
+          <div className="grid grid-cols-10 auto-rows-auto sm:flex sm:flex-col sm:items-center">
+            <span className="col-span-7 font-bold break-words sm:text-lg">
               {word.wordName}
             </span>
             <span
               className={cn(
                 "col-span-3 col-start-8 flex max-h-[30px] sm:min-w-[100px] items-center justify-center sm:justify-self-end text-xs px-2 py-1 rounded-md font-semibold border border-gray-200",
+                "sm:col-auto sm:col-start-auto sm:justify-self-auto sm:mt-2",
                 word.formalityLevel === "フォーマル" &&
                   "bg-secondary text-background",
                 word.formalityLevel === "普通" && "bg-primary text-background",
@@ -35,7 +36,7 @@ export const WordCard = React.memo(({ word }: { word: Word }) => (
               {word.formalityLevel}
             </span>
           </div>
-          <p className="mt-1 text-sm text-gray-600">{word.meaning}</p>
+          <p className="mt-1 text-sm text-gray-600 sm:mt-2">{word.meaning}</p>
         </Link>
       </motion.div>
     </CardContent>

--- a/language-app/src/app/word-search/_components/WordsList.tsx
+++ b/language-app/src/app/word-search/_components/WordsList.tsx
@@ -6,12 +6,19 @@ import LottieError from "@/components/LottieError";
 import { FilePlus2 } from "lucide-react";
 import { useWords } from "@/hooks/useWords"; // 作成したカスタムフックをインポート
 import { WordCard } from "@/app/word-search/_components/WordCard";
+import { cn } from "@/lib/utils";
 
-type WordsListProps = {
+type Props = {
   setIsSearchLoading: (value: boolean) => void;
+  errorClassName?: string;
+  className?: string;
 };
 
-const WordsList = ({ setIsSearchLoading }: WordsListProps) => {
+const WordsList = ({
+  setIsSearchLoading,
+  errorClassName,
+  className,
+}: Props) => {
   const { wordList, isLoading, error, totalPage } = useWords();
 
   // 親コンポーネントにローディング状態を伝える
@@ -22,7 +29,7 @@ const WordsList = ({ setIsSearchLoading }: WordsListProps) => {
   // エラー時
   if (error) {
     return (
-      <div className="flex flex-col items-center justify-center h-full">
+      <div className={cn(errorClassName)}>
         <div>
           {error}
           <LottieError />
@@ -34,7 +41,7 @@ const WordsList = ({ setIsSearchLoading }: WordsListProps) => {
   // ローディング中
   if (isLoading)
     return (
-      <div className="flex flex-col items-center justify-center h-full">
+      <div className={cn(errorClassName)}>
         <LottieLoading />
       </div>
     );
@@ -42,7 +49,7 @@ const WordsList = ({ setIsSearchLoading }: WordsListProps) => {
   // データが存在しない時
   if (wordList.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center h-full">
+      <div className={cn(errorClassName)}>
         <div className="text-2xl">
           <span className="flex items-center gap-1">
             右の <FilePlus2 /> から
@@ -57,10 +64,12 @@ const WordsList = ({ setIsSearchLoading }: WordsListProps) => {
 
   // データが存在する時
   return (
-    <div className="flex flex-col gap-4">
-      {wordList.map((word) => (
-        <WordCard key={word.id} word={word} />
-      ))}
+    <div className={cn(className)}>
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+        {wordList.map((word) => (
+          <WordCard key={word.id} word={word} />
+        ))}
+      </div>
       <PaginationList totalPage={totalPage} />
     </div>
   );

--- a/language-app/src/app/word-search/page.tsx
+++ b/language-app/src/app/word-search/page.tsx
@@ -20,8 +20,13 @@ export default function WordSearch() {
           className="h-[64px] z-10"
         />
 
-        <ScrollArea className="px-6 pb-6 max-h-[calc(100vh-75px-64px)]">
-          <WordsList setIsSearchLoading={setIsSearchLoading} />
+        <ScrollArea className="h-[calc(100vh-75px-64px)] px-6 pb-6">
+          <WordsList
+            setIsSearchLoading={setIsSearchLoading}
+            errorClassName="h-full flex items-center justify-center"
+            className="flex flex-col gap-4"
+          />
+
           <Chatbot />
         </ScrollArea>
       </div>


### PR DESCRIPTION
## 概要

`WordCard`および`WordsList`コンポーネントのレスポンシブ対応とスタイリングの改善を行いました。
また、カスタマイズ用のpropsを追加することでコンポーネントの柔軟性を高め、様々な画面サイズにおけるユーザー体験の向上、およびエラーハンドリングとローディング状態の表示を強化しました。

<table>
  <tr>
    <th>スマホ</th>
    <th>PC</th>
  </tr>
  <tr>
    <td>
<img width="300" alt="image" src="https://github.com/user-attachments/assets/3eb1de80-4b71-420b-aa5c-adfd08393ca3" />
</td>
    <td>
<img width="600" alt="image" src="https://github.com/user-attachments/assets/eeb9ed97-6707-41ea-affc-661529e76be8" />
</td>
  </tr>
</table>


## 確認手順

1. `word-search`ページにアクセスします。
2. 任意の単語を検索し、検索結果が`WordsList`コンポーネントに表示されることを確認します。
3. PCサイズの画面とスマートフォンサイズの画面（ブラウザのデベロッパーツール等で変更）の両方で、`WordCard`のレイアウトが崩れずに表示されることを確認します。

## 動作確認項目(チェックボックス)

- [ ] `WordCard`コンポーネントが、`sm:flex`や`sm:text-lg`といったクラスによって、画面サイズに応じてレスポンシブに表示されること。
- [ ] `WordsList`コンポーネントで、エラー、ローディング、コンテンツ表示の各レイアウトが正しく表示されること。
- [ ] `word-search`ページから渡されたカスタムスタイル(`className`)が`WordsList`コンポーネントに適用されていること。

## 確認が必要な項目

- [ ] 様々な画面幅（特にブレークポイントの前後）で表示崩れが発生していないか？
- [ ] `WordsList`コンポーネントに追加したprops (`errorClassName`, `className`) によって、エラー時やコンテンツ表示時のスタイルが意図通りにカスタマイズできているか？
- [ ] 今回の変更によって、他のコンポーネントに意図しない影響（デグレ）が発生していないか？

## 備考

今回のプルリクエストは、主に`WordCard`と`WordsList`コンポーネントのスタイリングとレスポンシブ対応の改善に焦点を当てています。ロジックに関する大きな変更はありません。